### PR TITLE
improve error messages on missing `Admin:*` entries

### DIFF
--- a/backend/Infrastructure/Services/DbInitializer.cs
+++ b/backend/Infrastructure/Services/DbInitializer.cs
@@ -62,7 +62,7 @@ public class DbInitializer(
 			FirstName = "Олег",
 			LastName = "Ольжич",
 			Email = configuration["Admin:Email"]
-				?? throw new NullReferenceException("Admin:Email"),
+				?? throw new NullReferenceException("You need to set up Admin:Email in your configuration"),
 			UserName = "admin",
 			Photo = "default.jpg"
 			//Photo = await imageService.SaveImageAsync(defaultBase64Image)
@@ -71,7 +71,7 @@ public class DbInitializer(
 		IdentityResult result = await userManager.CreateAsync(
 			admin,
 			configuration["Admin:Password"]
-				?? throw new NullReferenceException("Admin:Password")
+				?? throw new NullReferenceException("You need to set up Admin:Password in your configuration")
 		);
 
 		if (!result.Succeeded)


### PR DESCRIPTION
it's not important but it was a bit annoying and not self-explanatory at all